### PR TITLE
Let's fix conversation with Tomitake in tata_009.txt

### DIFF
--- a/Update/tata_009.txt
+++ b/Update/tata_009.txt
@@ -473,6 +473,8 @@ void main()
 	DrawBustshot( 2, "tm_si_de_a1", 0, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 10, 400, TRUE );
 	FadeOutBGM( 1, 1000, TRUE );
 
+// REMOVE FROM HERE
+
 //「やぁ、申し訳ないね＠君、雛見沢の人だよね？＠
 	if (GetGlobalFlag(GADVMode)) { OutputLineAll("", NULL, Line_ContinueAfterTyping); }
 	PlaySE(4, "", 128, 64);
@@ -516,6 +518,13 @@ void main()
 	ClearMessage();
 	DisableWindow();
 	DrawBustshot( 2, "tm_si_ko_a1", 0, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 10, 200, TRUE );
+
+// REMOVE UNTIL HERE, REPLACEMENT TEXT:
+// 富竹rvS03/08/140800001.「こんにちは、圭一くん。kvS03/08/140800001_1.こんなとこで会うとはね」
+// 圭一rvS03/01/140100246.「……………富竹さん？」
+// r富竹さんは気さくな仕草で手を上げると、にっこりと笑いかけた。
+// END
+
 
 //「古手神社って、ここからどう行けばいいか、教えてもらえないかい＠　マップを宿に置いてきちゃったみたいでね＠困ってたんだよ。＠
 //「ここから神社ですか＠　...............んん、＠
@@ -632,6 +641,8 @@ void main()
 		   NULL, " It was easier for me, too, that he was under that impression.", Line_Normal);
 	ClearMessage();
 
+// REMOVE FROM HERE
+
 //「僕は富竹＠フリーカメラマンさ＠専門は野鳥と風景＠まだまだ無名だけどね。＠
 //　ただ神社に案内するだけの関係で、自己紹介というのも滑稽な話だが、名乗られた以上、自分も名乗らないわけにはいかないしな￥
 	if (GetGlobalFlag(GADVMode)) { OutputLineAll("", NULL, Line_ContinueAfterTyping); }
@@ -681,6 +692,12 @@ void main()
 	DisableWindow();
 	DrawSceneWithMask( "bg_141", "right", 0, 0, 300 );
 	PlayBGM( 2, "lsys19", 128, 0 );
+
+// REMOVE UNTIL HERE, REPLACEMENT TEXT:
+// 富竹rvS03/08/140800012.「いやぁ、今日もいい天気でよかったよ。kvS03/08/140800013.天気予報だと寒冷前線が近づいてるって言ってたけど、まだ大丈夫みたいだね」
+// 圭一rvS03/01/140100251.「そうですね。kvS03/01/140100252.でもまだ、梅雨明けはしてないみたいですよ」
+// 富竹rvS03/08/140800014.「うーん、明日は遠出するつもりだったんだけど……。kvS03/08/140800015.ちょっと、計画を立て直した方がいいかもしれないなぁ」
+// END
 
 //　道中、富竹さんは、雛見沢の自然がいかに貴重で、珍しい野鳥の宝庫であるかを聞きもしないのに延々と説明してくれた＠
 //　...中身に興味がないが、楽しそうなので口を挟まずに放っておくことにする￥


### PR DESCRIPTION
@ItaloKnox I kind of reported this previously with a promise of a better specification for you. Then I of course completely forgot about it. So finally here it is.

I added some comments into the script about what text should be cut out and the japanese text and voices it should be replaced with.

We could use the new `GCensor` flag from @P-Chang here to preserve both old and new text - the flag would be used to decide which branch to use. The question is whether we want to do it as it is more work - not much in this case but in other cases it could be far worse. I'm actually slightly leaning toward not doing this as we have enough of work already. I don't think anyone from the team asked for this flag to be implemented. Your opinion?