### PR TITLE
Waiting bug

### DIFF
--- a/Update/tata_010.txt
+++ b/Update/tata_010.txt
@@ -846,15 +846,25 @@ void main()
 //!sd/
 	SetSpeedOfMessage( FALSE, 0, );
 	ShakeScreen( 1, 50, 20, 3, 0, );
-	OutputLineAll(NULL, "", Line_Continue);
+
+	Wait( 2000 );
 
 //先生、昨日あんた、絶対に助けるから大丈夫って言わなかったか？＠　これはどういうことだよ？＠　おかしいじゃねえかよ？＠　ええッおい！！＠
 	OutputLine(NULL, "　先生、昨日あんた、絶対に助けるから大丈夫って言わなかったか？！",
 		   NULL, " Sensei, didn't you say it was going to be all right, since you'd definitely save her?!", Line_Continue);
+
+	Wait( 1000 );
+
 	OutputLine(NULL, "　これはどういうことだよ？！",
 		   NULL, " What's the meaning of this?!", Line_Continue);
+
+	Wait( 1000 );
+
 	OutputLine(NULL, "　おかしいじゃねえかよ？！",
 		   NULL, " This doesn't make any sense!!", Line_Continue);
+
+	Wait( 1000 );
+
 	OutputLine(NULL, "　ええッおい！！」",
 		   NULL, " Answer me, damn it!!\"", GetGlobalFlag(GLinemodeSp));
 	if (GetGlobalFlag(GADVMode)) { ClearMessage(); } else { OutputLineAll(NULL, "\n", Line_ContinueAfterTyping); }


### PR DESCRIPTION
@P-Chang I think I might have found a bug in the waiting logic. In the case commited here the initial `Wait( 2000 );` seemd to work just fine. But all of the `Wait( 1000 );` calls seem to be ignored. I don't quite undestand why.

This sort of waiting is sometimes used in the script if there is a voice file that covers multiple sentences to try to better match the text and the voice. I tried to re-use that here because originallly this part used Line_WaitForInput instead which didn't look good in auto mode (the first part of the text waited for the entire voice).

Here is a save file near the location: https://www.dropbox.com/s/jni3km228uw0qhn/save058.dat?dl=0