### PR TITLE
Various small fixes

### DIFF
--- a/Update/omake_03.txt
+++ b/Update/omake_03.txt
@@ -309,8 +309,8 @@ void main()
 	OutputLine(NULL, "「ありがとうございました！",
 		   NULL, "\"Thank you very much!", Line_WaitForInput);
 	//VoiceMatching
-	if(GetGlobalFlag(GCensor) >= 3){ModCallScriptSection("ztata_omake_03_vm0x_n01","dialog007");}
-	if(GetGlobalFlag(GCensor) <= 2){ModCallScriptSection("ztata_omake_03_vm00_n01","dialog007");}
+	if(GetGlobalFlag(GCensor) >= 2){ModCallScriptSection("ztata_omake_03_vm0x_n01","dialog007");}
+	if(GetGlobalFlag(GCensor) <= 1){ModCallScriptSection("ztata_omake_03_vm00_n01","dialog007");}
 	//VoiceMatchingEnd
 	DisableWindow();
 	ModSetLayerFilter(1, 256, "none");
@@ -322,8 +322,8 @@ void main()
 	OutputLine(NULL, "「皆さん、どうもこんにちは！",
 		   NULL, "\"Hello there, everyone!", Line_WaitForInput);
 	//VoiceMatching
-	if(GetGlobalFlag(GCensor) >= 3){ModCallScriptSection("ztata_omake_03_vm0x_n01","dialog008");}
-	if(GetGlobalFlag(GCensor) <= 2){ModCallScriptSection("ztata_omake_03_vm00_n01","dialog008");}
+	if(GetGlobalFlag(GCensor) >= 2){ModCallScriptSection("ztata_omake_03_vm0x_n01","dialog008");}
+	if(GetGlobalFlag(GCensor) <= 1){ModCallScriptSection("ztata_omake_03_vm00_n01","dialog008");}
 	//VoiceMatchingEnd
 
 

--- a/Update/tata_001.txt
+++ b/Update/tata_001.txt
@@ -1775,7 +1775,7 @@ void main()
 		   NULL, " a bag of salt in Mion's rice,", Line_WaitForInput);
 	ModPlayVoiceLS(4, 1, "ps3/s19/01/hr_kei23220", 256, TRUE);
 	OutputLine(NULL, "…俺の鍋をひっくり返しやがってー！！」",
-		   NULL, " ...and you flipped over my pan!!\"", Line_Normal);
+		   NULL, " ...and you flipped over my pot!!\"", Line_Normal);
 	ClearMessage();
 
 //　以前のカレー勝負の時の因縁が再発！＠

--- a/Update/tata_003.txt
+++ b/Update/tata_003.txt
@@ -5572,7 +5572,7 @@ void main()
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#956f6e>圭一</color>", NULL, "<color=#956f6e>Keiichi</color>", NULL, Line_ContinueAfterTyping); }
 	ModPlayVoiceLS(4, 1, "ps3/s19/01/hr_kei29830", 256, TRUE);
 	OutputLine(NULL, "　さっき言ったはずだ！！",
-		   NULL, "I already said!!", Line_Continue);
+		   NULL, " I already said!!", Line_Continue);
 	Wait( 1500 );
 	OutputLine(NULL, "　認めるか否かが男の分岐路なのだ！！！",
 		   NULL, " Admitting your perversion is what separates the boys from the men!!!", Line_Continue);
@@ -5591,7 +5591,7 @@ void main()
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#956f6e>圭一</color>", NULL, "<color=#956f6e>Keiichi</color>", NULL, Line_ContinueAfterTyping); }
 	ModPlayVoiceLS(4, 1, "ps3/s19/01/hr_kei29830_01", 256, TRUE);
 	OutputLine(NULL, "　俺と一緒に…俺たちの世界を認めるんだぁああぁああぁッ！！！！」",
-		   NULL, "Come with me... and accept that it is our world!!!!\"", GetGlobalFlag(GLinemodeSp));
+		   NULL, " Come with me... and accept that it is our world!!!!\"", GetGlobalFlag(GLinemodeSp));
 	if (GetGlobalFlag(GADVMode)) { ClearMessage(); } else { OutputLineAll(NULL, "\n", Line_ContinueAfterTyping); }
 
 

--- a/Update/tata_009.txt
+++ b/Update/tata_009.txt
@@ -3791,7 +3791,7 @@ void main()
 	OutputLine(NULL, "　もう遅い。",
 		   NULL, "It was too late.", Line_WaitForInput);
 	OutputLine(NULL, "……もう賽は振られてしまった。",
-		   NULL, " ...The dice had been cast.", GetGlobalFlag(GLinemodeSp));
+		   NULL, " ...The die had been cast.", GetGlobalFlag(GLinemodeSp));
 	if (GetGlobalFlag(GADVMode)) { ClearMessage(); } else { OutputLineAll(NULL, "\n", Line_ContinueAfterTyping); }
 
 

--- a/Update/tata_tips_10.txt
+++ b/Update/tata_tips_10.txt
@@ -44,7 +44,7 @@ void main()
 //その監護する児童（十八歳に満たない者をいう。以下同じ）に対し、次に掲げる行為をすることをいう。/
 	if (GetGlobalFlag(GADVMode)) { OutputLineAll("", NULL, Line_ContinueAfterTyping); }
 	OutputLine(NULL, "その監護する児童（十八歳に満たない者をいう。以下同じ）に対し、次に掲げる行為をすることをいう。",
-		   NULL, "against a child (meaning a person who is under 18 years of age; hereinafter the same shall apply):", Line_ContinueAfterTyping);
+		   NULL, " against a child (meaning a person who is under 18 years of age; hereinafter the same shall apply):", Line_ContinueAfterTyping);
 
 	FadeOutBGM( 2, 10, TRUE );
 	OutputLineAll(NULL, "", Line_Normal);

--- a/Update/tata_tips_19.txt
+++ b/Update/tata_tips_19.txt
@@ -53,7 +53,7 @@ void main()
 		   NULL, "There is a theory stating the shrine, or \"yashiro,\" dedicated to Oyashiro-sama itself became an object of worship.", GetGlobalFlag(GLinemodeSp));
 	if (GetGlobalFlag(GADVMode)) { OutputLineAll("", NULL, Line_ContinueAfterTyping); }
 	OutputLine(NULL, "「御社さま」と呼ばれるに至ったと言う説があるが、実にセンスの欠片もない。",
-		   NULL, "And that people began calling it \"o-yashiro-sama,\" or \"lord honorable shrine\"—but this doesn't make a bit of sense.", Line_Normal);
+		   NULL, " And that people began calling it \"o-yashiro-sama,\" or \"lord honorable shrine\"—but this doesn't make a bit of sense.", Line_Normal);
 	ClearMessage();
 
 	PlaySE( 3, "wa_021", 56, 64 );

--- a/Update/ztata_omake_03_vm00_n01.txt
+++ b/Update/ztata_omake_03_vm00_n01.txt
@@ -354,6 +354,6 @@ void dialog029()
 		   NULL, " You'll get too close to the Three Families' secrets, be imprisoned, and then get tortured!", Line_WaitForInput);
 	ModPlayVoiceLS(4, 3, "ps3/s20/03/440300397", 256, TRUE);
 	OutputLine(NULL, "　非業の最期を遂げる役に決まってるー！！」",
-		   NULL, " You're a shoe-in to meet a violent, unnatural death!!\"", GetGlobalFlag(GLinemodeSp));
+		   NULL, " You're a shoo-in to meet a violent, unnatural death!!\"", GetGlobalFlag(GLinemodeSp));
 	if (GetGlobalFlag(GADVMode)) { ClearMessage(); } else { OutputLineAll(NULL, "\n", Line_ContinueAfterTyping); }
 }

--- a/Update/ztata_omake_03_vm0x_n01.txt
+++ b/Update/ztata_omake_03_vm0x_n01.txt
@@ -400,6 +400,6 @@ void dialog029()
 		   NULL, " You'll get too close to the Three Families' secrets, be imprisoned, and then get tormented!", Line_WaitForInput);
 	ModPlayVoiceLS(4, 3, "ps3/s20/03/440300397", 256, TRUE);
 	OutputLine(NULL, "　ヒサンな最期を遂げる役に決まってるー！！」",
-		   NULL, " You're a shoe-in to meet a violent, unnatural death!!\"", GetGlobalFlag(GLinemodeSp));
+		   NULL, " You're a shoo-in to meet a violent, unnatural death!!\"", GetGlobalFlag(GLinemodeSp));
 	if (GetGlobalFlag(GADVMode)) { ClearMessage(); } else { OutputLineAll(NULL, "\n", Line_ContinueAfterTyping); }
 }

--- a/Update/ztata_tips_02_vm0x_n01.txt
+++ b/Update/ztata_tips_02_vm0x_n01.txt
@@ -25,7 +25,7 @@ void dialog001()
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#956f6e>圭一</color>", NULL, "<color=#956f6e>Keiichi</color>", NULL, Line_ContinueAfterTyping); }
 	ModPlayVoiceLS(4, 1, "ps3/s20/01/440100119", 256, TRUE);
 	OutputLine(NULL, "「…………どうやら、だれが罠をしかけたのかは問答無用、ってところだな」",
-		   NULL, "\"...Looks like there's no use talking to the person who set this trap.\"", GetGlobalFlag(GLinemodeSp));
+		   NULL, "\"...Looks like there's no use talking to the person who set up that trick.\"", GetGlobalFlag(GLinemodeSp));
 	if (GetGlobalFlag(GADVMode)) { ClearMessage(); } else { OutputLineAll(NULL, "\n", Line_ContinueAfterTyping); }
 	DisableWindow();
 	ModDrawCharacter(2, 4, "sprite/sa1a_odoroki_a1_", "1", 0, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 10, 200, TRUE );


### PR DESCRIPTION
Changes are as follows:

1. In tata_001, corrected "pan" to "pot".
2. In tata_003, tata_tips_10, and tata_tips_19 added spaces at the start of lines that were missing them.
3. In tata_009, addressed #79 by correcting"the dice have been cast" to "the die has been cast".
4. For tips_02, changed the console version of a line to use the wording "who set up that trick" instead of "who set up this trap". I think "who tricked them" may be more natural, but regardless using "trap" makes the following lines nonsensical. See the second and third lines here for how it read before this change:

![20200726084313_1](https://user-images.githubusercontent.com/59459967/88579624-590c6b00-d018-11ea-88c5-60424b96591c.jpg)

(Actually, I think the console line may be mistranslated to begin with, but I'm not certain and will need someone else to confirm it.)

5. Both versions of a line in omake03 had "shoe-in" instead of "shoo-in".
6. In omake03, I configured Chie's introduction to now play the console lines by default. The PC lines talk about how she only got art in this arc, but currently she has portraits shown starting from the back half of Onikakushi, so those lines don't make much sense.