### PR TITLE
Adjusted voice matching level

### DIFF
--- a/Update/tata_004.txt
+++ b/Update/tata_004.txt
@@ -130,8 +130,8 @@ void main()
 	OutputLine(NULL, "朝食は一日の基本だもんな。",
 		   NULL, " Breakfast is an important part of the day.", Line_WaitForInput);
 	//VoiceMatching
-	if(GetGlobalFlag(GCensor) >= 4){ModCallScriptSection("ztata_004_vm0x_n01","dialog000");}
-	if(GetGlobalFlag(GCensor) <= 3){ModCallScriptSection("ztata_004_vm00_n01","dialog000");}
+	if(GetGlobalFlag(GCensor) >= 2){ModCallScriptSection("ztata_004_vm0x_n01","dialog000");}
+	if(GetGlobalFlag(GCensor) <= 1){ModCallScriptSection("ztata_004_vm00_n01","dialog000");}
 	//VoiceMatchingEnd
 
 
@@ -2601,8 +2601,8 @@ void main()
 	FadeOutBGM( 1, 1000, TRUE );
 
 	//VoiceMatching
-	if(GetGlobalFlag(GCensor) >= 4){ModCallScriptSection("ztata_004_vm0x_n01","dialog001");}
-	if(GetGlobalFlag(GCensor) <= 3){ModCallScriptSection("ztata_004_vm00_n01","dialog001");}
+	if(GetGlobalFlag(GCensor) >= 2){ModCallScriptSection("ztata_004_vm0x_n01","dialog001");}
+	if(GetGlobalFlag(GCensor) <= 1){ModCallScriptSection("ztata_004_vm00_n01","dialog001");}
 	//VoiceMatchingEnd
 
 	PlaySE( 3, "wa_029", 56, 64 );
@@ -2670,8 +2670,8 @@ void main()
 	PlayBGM( 2, "lsys12", 56, 0 );
 
 	//VoiceMatching
-	if(GetGlobalFlag(GCensor) >= 4){ModCallScriptSection("ztata_004_vm0x_n01","dialog002");}
-	if(GetGlobalFlag(GCensor) <= 3){ModCallScriptSection("ztata_004_vm00_n01","dialog002");}
+	if(GetGlobalFlag(GCensor) >= 2){ModCallScriptSection("ztata_004_vm0x_n01","dialog002");}
+	if(GetGlobalFlag(GCensor) <= 1){ModCallScriptSection("ztata_004_vm00_n01","dialog002");}
 	//VoiceMatchingEnd
 
 


### PR DESCRIPTION
I separated this from my fixes commit since it's up for debate and I don't want obvious fixes impacted by that, but I personally think this is worth changing.

tata_004 uses the censored PS3 lines as the default for about half of the lines. One of the PC sections used is dialog002, which contains a particularly extreme joke about Satoko; given that there's an alternatives available, I think it's just needlessly upsetting to default to. And if the censored lines are already being used as a default for tata_004's dialog003-005, might as well be consistent for all of them; I don't think this is inconsistent with what's used as the default in similar situations elsewhere, like tata_003.